### PR TITLE
Fix Update failure issue after recent HACS 2.0 upgrade

### DIFF
--- a/custom_components/miraie/manifest.json
+++ b/custom_components/miraie/manifest.json
@@ -17,5 +17,5 @@
     "@rkzofficial"
   ],
   "iot_class": "cloud_push",
-  "version": "1.0.8"
+  "version": "1.0.9"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,3 @@
+{
+  "name": "MirAIe"
+}


### PR DESCRIPTION
Add the missing `hacs.json` file in the project root.