### PR TITLE
Non-convertible ac support

### DIFF
--- a/custom_components/miraie/climate.py
+++ b/custom_components/miraie/climate.py
@@ -173,7 +173,7 @@ class MirAIeClimate(ClimateEntity):
 
     @property
     def preset_mode(self) -> str | None:
-        if self.device.status.converti_mode == ConvertiMode.OFF:
+        if self.device.status.converti_mode in [ConvertiMode.OFF, ConvertiMode.NS]:
             return self.device.status.preset_mode.value
         return f"cv {self.device.status.converti_mode.value}"
 

--- a/custom_components/miraie/manifest.json
+++ b/custom_components/miraie/manifest.json
@@ -17,5 +17,5 @@
     "@rkzofficial"
   ],
   "iot_class": "cloud_push",
-  "version": "1.0.9"
+  "version": "1.0.10"
 }

--- a/custom_components/miraie/manifest.json
+++ b/custom_components/miraie/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/miraie",
   "requirements": [
-    "miraie-ac==1.0.7",
+    "miraie-ac==1.0.8",
     "asyncio>=3.4.3",
     "aiomqtt>=2.0.1"
   ],


### PR DESCRIPTION
Due to recent changes to support convertible AC modes the non-convertible ACs failed to be registered. The patch fixes the same.