### PR TITLE
Remove asyncio requirement

### DIFF
--- a/custom_components/miraie/manifest.json
+++ b/custom_components/miraie/manifest.json
@@ -5,7 +5,6 @@
   "documentation": "https://www.home-assistant.io/integrations/miraie",
   "requirements": [
     "miraie-ac==1.1.1",
-    "asyncio>=3.4.3",
     "aiomqtt>=2.0.1"
   ],
   "ssdp": [],


### PR DESCRIPTION
Homeassistant is on Python 3.13 so we can drop the asyncio requirement.