### PR TITLE
Make display mode toggle unavailable when the device is offline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/*
 .DS_Store
+.venv

--- a/custom_components/miraie/switch.py
+++ b/custom_components/miraie/switch.py
@@ -76,6 +76,11 @@ class MirAIeDisplaySwitch(SwitchEntity):
         """Return True if display is on."""
         return self.device.status.display_mode == DisplayMode.ON
 
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.device.status.is_online
+
     async def async_turn_off(self) -> None:
         await self.device.set_display_mode(DisplayMode.OFF)
 


### PR DESCRIPTION
Make the `Display mode` toggle switch unavailable when the device gets offline like the main Climate entity.