### PR TITLE
Expose AC timer services and sensors

### DIFF
--- a/custom_components/miraie/__init__.py
+++ b/custom_components/miraie/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
+from .services import async_register_services, async_unregister_services
 
 # For your initial PR, limit it to 1 platform.
 PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.SWITCH, Platform.SENSOR]
@@ -23,6 +24,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN][entry.entry_id] = hub
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    await async_register_services(hass)
 
     return True
 
@@ -31,5 +33,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
+        if not hass.data[DOMAIN]:
+            await async_unregister_services(hass)
 
     return unload_ok

--- a/custom_components/miraie/manifest.json
+++ b/custom_components/miraie/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/miraie",
   "requirements": [
-    "miraie-ac==1.1.1",
+    "miraie-ac>=1.2.0",
     "asyncio>=3.4.3",
     "aiomqtt>=2.0.1"
   ],
@@ -18,5 +18,5 @@
     "@gutpull"
   ],
   "iot_class": "cloud_push",
-  "version": "1.1.5"
+  "version": "1.2.0"
 }

--- a/custom_components/miraie/sensor.py
+++ b/custom_components/miraie/sensor.py
@@ -17,6 +17,57 @@ from .logger import LOGGER
 from .utils import get_last_sunday
 
 
+class MirAIeTimerSensor(SensorEntity):
+    """Timestamp sensor for an AC's scheduled on-timer or off-timer.
+
+    The state is the absolute UTC datetime when the AC will fire the
+    timer, or `None` (unavailable) if no timer is set.
+    """
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_should_poll = False
+
+    def __init__(self, device: MirAIeDevice, kind: str):
+        if kind not in ("off", "on"):
+            raise ValueError(kind)
+        self.device = device
+        self.kind = kind
+        self._attr_unique_id = f"{device.id}_{kind}_timer_at"
+        self._attr_name = f"{device.friendly_name} {kind.capitalize()} timer"
+        self._attr_translation_key = f"{kind}_timer"
+
+    @property
+    def icon(self) -> str:
+        return "mdi:timer-off-outline" if self.kind == "off" else "mdi:timer-play-outline"
+
+    @property
+    def native_value(self) -> datetime | None:
+        epoch = self.device.status.off_timer_at if self.kind == "off" else self.device.status.on_timer_at
+        if epoch is None or epoch <= 0:
+            return None
+        return datetime.fromtimestamp(epoch, tz=timezone.utc)
+
+    @property
+    def available(self) -> bool:
+        return self.device.status.is_online
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.device.id)},
+            name=self.device.friendly_name,
+            manufacturer=self.device.details.brand,
+            model=self.device.details.model_number,
+            sw_version=self.device.details.firmware_version,
+        )
+
+    async def async_added_to_hass(self) -> None:
+        self.device.register_callback(self.async_write_ha_state)
+
+    async def async_will_remove_from_hass(self) -> None:
+        self.device.remove_callback(self.async_write_ha_state)
+
+
 CUTOFF_HOUR = 12
 
 class MirAIeEnergySensor(SensorEntity, ABC):
@@ -153,17 +204,23 @@ class MirAIeMonthlyEnergySensor(MirAIeEnergySensor):
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
     """Set up MirAIe energy sensors from a config entry."""
     hub: MirAIeHub = hass.data[DOMAIN][entry.entry_id]
-    sensors = []
+    energy_sensors: list[MirAIeEnergySensor] = []
+    timer_sensors: list[MirAIeTimerSensor] = []
     for device in hub.home.devices:
-        sensors += [
+        energy_sensors += [
             MirAIeDailyEnergySensor(hub, device),
             MirAIeWeeklyEnergySensor(hub, device),
             MirAIeMonthlyEnergySensor(hub, device),
         ]
-    async_add_entities(sensors, update_before_add=True)  # Register sensors
+        timer_sensors += [
+            MirAIeTimerSensor(device, "off"),
+            MirAIeTimerSensor(device, "on"),
+        ]
+    async_add_entities(energy_sensors, update_before_add=True)
+    async_add_entities(timer_sensors)
 
     async def update_sensors(now=None):
-        for sensor in sensors:
+        for sensor in energy_sensors:
             await sensor.async_update()
             sensor.async_write_ha_state()  # Ensure HA is notified of new data
 

--- a/custom_components/miraie/services.py
+++ b/custom_components/miraie/services.py
@@ -1,0 +1,115 @@
+"""Service handlers for the mirAIe integration.
+
+Exposes set_off_timer / set_on_timer / cancel_off_timer / cancel_on_timer
+/ clear_timers as Home Assistant services targeting climate entities.
+
+Each service resolves the target climate entity to its underlying
+MirAIeDevice and invokes the device-side timer methods (which publish
+the timer to the AC over MQTT).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+import voluptuous as vol
+from miraie_ac import Device as MirAIeDevice, MirAIeHub
+
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+
+from .const import DOMAIN
+from .logger import LOGGER
+
+SERVICE_SET_OFF_TIMER = "set_off_timer"
+SERVICE_SET_ON_TIMER = "set_on_timer"
+SERVICE_CANCEL_OFF_TIMER = "cancel_off_timer"
+SERVICE_CANCEL_ON_TIMER = "cancel_on_timer"
+SERVICE_CLEAR_TIMERS = "clear_timers"
+
+DURATION_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+        vol.Required("duration"): cv.time_period,
+    }
+)
+
+CANCEL_SCHEMA = vol.Schema({vol.Required(ATTR_ENTITY_ID): cv.entity_ids})
+
+
+def _devices_for_call(hass: HomeAssistant, call: ServiceCall) -> list[MirAIeDevice]:
+    """Resolve the call's target climate entities to MirAIeDevice objects."""
+    registry = er.async_get(hass)
+    devices: list[MirAIeDevice] = []
+    for entity_id in call.data[ATTR_ENTITY_ID]:
+        entry = registry.async_get(entity_id)
+        if entry is None or entry.platform != DOMAIN:
+            LOGGER.warning("Skipping non-miraie entity %s", entity_id)
+            continue
+        # The unique_id is the device id (set in MirAIeClimate.__init__).
+        for hub in hass.data[DOMAIN].values():
+            if not isinstance(hub, MirAIeHub):
+                continue
+            device = next((d for d in hub.home.devices if d.id == entry.unique_id), None)
+            if device is not None:
+                devices.append(device)
+                break
+    return devices
+
+
+def _seconds(call: ServiceCall) -> int:
+    duration: timedelta = call.data["duration"]
+    return int(duration.total_seconds())
+
+
+async def async_register_services(hass: HomeAssistant) -> None:
+    """Register the timer services with Home Assistant."""
+
+    if hass.services.has_service(DOMAIN, SERVICE_SET_OFF_TIMER):
+        return
+
+    async def _set_off_timer(call: ServiceCall) -> None:
+        seconds = _seconds(call)
+        for d in _devices_for_call(hass, call):
+            LOGGER.debug("set_off_timer device=%s seconds=%d", d.friendly_name, seconds)
+            await d.set_off_timer(seconds)
+
+    async def _set_on_timer(call: ServiceCall) -> None:
+        seconds = _seconds(call)
+        for d in _devices_for_call(hass, call):
+            LOGGER.debug("set_on_timer device=%s seconds=%d", d.friendly_name, seconds)
+            await d.set_on_timer(seconds)
+
+    async def _cancel_off_timer(call: ServiceCall) -> None:
+        for d in _devices_for_call(hass, call):
+            LOGGER.debug("cancel_off_timer device=%s", d.friendly_name)
+            await d.cancel_off_timer()
+
+    async def _cancel_on_timer(call: ServiceCall) -> None:
+        for d in _devices_for_call(hass, call):
+            LOGGER.debug("cancel_on_timer device=%s", d.friendly_name)
+            await d.cancel_on_timer()
+
+    async def _clear_timers(call: ServiceCall) -> None:
+        for d in _devices_for_call(hass, call):
+            LOGGER.debug("clear_timers device=%s", d.friendly_name)
+            await d.clear_timers()
+
+    hass.services.async_register(DOMAIN, SERVICE_SET_OFF_TIMER, _set_off_timer, schema=DURATION_SCHEMA)
+    hass.services.async_register(DOMAIN, SERVICE_SET_ON_TIMER, _set_on_timer, schema=DURATION_SCHEMA)
+    hass.services.async_register(DOMAIN, SERVICE_CANCEL_OFF_TIMER, _cancel_off_timer, schema=CANCEL_SCHEMA)
+    hass.services.async_register(DOMAIN, SERVICE_CANCEL_ON_TIMER, _cancel_on_timer, schema=CANCEL_SCHEMA)
+    hass.services.async_register(DOMAIN, SERVICE_CLEAR_TIMERS, _clear_timers, schema=CANCEL_SCHEMA)
+
+
+async def async_unregister_services(hass: HomeAssistant) -> None:
+    for service in (
+        SERVICE_SET_OFF_TIMER,
+        SERVICE_SET_ON_TIMER,
+        SERVICE_CANCEL_OFF_TIMER,
+        SERVICE_CANCEL_ON_TIMER,
+        SERVICE_CLEAR_TIMERS,
+    ):
+        hass.services.async_remove(DOMAIN, service)

--- a/custom_components/miraie/services.yaml
+++ b/custom_components/miraie/services.yaml
@@ -1,0 +1,61 @@
+set_off_timer:
+  name: Set off timer
+  description: >-
+    Schedule the AC to turn off after a duration. The timer fires on the AC
+    itself, so it survives loss of internet or Home Assistant connectivity.
+    The MirAIe broker rounds durations up to the next 60-second boundary.
+    Preserves any existing on-timer.
+  target:
+    entity:
+      integration: miraie
+      domain: climate
+  fields:
+    duration:
+      name: Duration
+      description: How long from now until the AC turns off.
+      required: true
+      example: "01:00:00"
+      selector:
+        duration:
+
+set_on_timer:
+  name: Set on timer
+  description: >-
+    Schedule the AC to turn on after a duration. Preserves any existing
+    off-timer.
+  target:
+    entity:
+      integration: miraie
+      domain: climate
+  fields:
+    duration:
+      name: Duration
+      description: How long from now until the AC turns on.
+      required: true
+      example: "00:30:00"
+      selector:
+        duration:
+
+cancel_off_timer:
+  name: Cancel off timer
+  description: Clear any scheduled turn-off. Leaves the on-timer untouched.
+  target:
+    entity:
+      integration: miraie
+      domain: climate
+
+cancel_on_timer:
+  name: Cancel on timer
+  description: Clear any scheduled turn-on. Leaves the off-timer untouched.
+  target:
+    entity:
+      integration: miraie
+      domain: climate
+
+clear_timers:
+  name: Clear timers
+  description: Clear both the on-timer and off-timer.
+  target:
+    entity:
+      integration: miraie
+      domain: climate


### PR DESCRIPTION
## Summary

Surfaces the timer support added in [miraie-ac#17](https://github.com/rkzofficial/miraie-ac/pull/17) (v1.2.0) as Home Assistant services and sensors. **Depends on that PR being merged and a 1.2.0 release on PyPI.**

### Why device-side timers matter

The MirAIe broker stores timers on the AC unit itself. Once published, the AC fires the timer using its own onboard clock — even if Home Assistant restarts, the internet drops, or the MirAIe broker is unreachable. This is meaningfully more robust than HA-side `delay:` actions, which silently abandon their countdown on a restart.

### New services

```yaml
service: miraie.set_off_timer
target:
  entity_id: climate.entertainment_rm_ac
data:
  duration: "01:00:00"

service: miraie.set_on_timer
target:
  entity_id: climate.imagine_room_ac
data:
  duration: "00:30:00"

service: miraie.cancel_off_timer
service: miraie.cancel_on_timer
service: miraie.clear_timers
```

All services accept a list of climate entity targets. The MirAIe broker rounds durations up to the next 60-second boundary.

### New sensors

For each AC, two timestamp sensors are added:

- `sensor.<ac>_off_timer` — datetime when the AC will turn off, or `unavailable` if no off-timer is set.
- `sensor.<ac>_on_timer`  — datetime when the AC will turn on,  or `unavailable` if no on-timer is set.

`SensorDeviceClass.TIMESTAMP`, so HA renders them as "in 30 minutes" / "in 1 hour" automatically.

### Files

- `services.yaml` / `services.py` — service definitions and handlers.
- `__init__.py` — registers services on first config-entry setup, unregisters on last unload.
- `sensor.py` — adds `MirAIeTimerSensor` (timestamp), instantiates two per device alongside the existing energy sensors.
- `manifest.json` — `miraie-ac>=1.2.0`, integration version → 1.2.0.

## Test plan

- [ ] Reload the integration; verify five new `miraie.*` services appear in Developer Tools → Services.
- [ ] Verify two new `sensor.*_timer` entities per AC appear; both show `unavailable` initially.
- [ ] Call `miraie.set_off_timer` (duration: 2 min) on a climate entity → sensor reports datetime ~2 min ahead, AC actually turns off when it fires.
- [ ] Call `miraie.set_on_timer` then `miraie.cancel_off_timer` → off sensor returns to `unavailable`, on sensor unaffected.
- [ ] Call `miraie.clear_timers` → both sensors return to `unavailable`.
- [ ] Restart Home Assistant mid-countdown → AC still fires the timer at the scheduled time (the whole point of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)