### PR TITLE
Add energy history backfill via HA recorder statistics

### DIFF
--- a/custom_components/miraie/__init__.py
+++ b/custom_components/miraie/__init__.py
@@ -1,13 +1,17 @@
 """The mirAIe integration."""
 from __future__ import annotations
 
+from datetime import date
+
 from miraie_ac import MirAIeBroker, MirAIeHub
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.event import async_track_time_change
 
-from .const import DOMAIN
+from .const import CONF_INSTALL_DATE, DOMAIN
+from .sensor import async_backfill_energy_statistics, six_months_ago
 
 # For your initial PR, limit it to 1 platform.
 PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.SWITCH, Platform.SENSOR]
@@ -23,6 +27,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN][entry.entry_id] = hub
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    default_start = entry.options.get(CONF_INSTALL_DATE)
+    if default_start:
+        start_date = date.fromisoformat(default_start)
+    else:
+        start_date = six_months_ago(date.today())
+    for device in hub.home.devices:
+        hass.async_create_task(
+            async_backfill_energy_statistics(hass, hub, device, start_date)
+        )
+
+    async def nightly_backfill(now=None):
+        for device in hub.home.devices:
+            hass.async_create_task(
+                async_backfill_energy_statistics(hass, hub, device, start_date)
+            )
+
+    async_track_time_change(hass, nightly_backfill, hour=0, minute=5, second=0)
 
     return True
 

--- a/custom_components/miraie/config_flow.py
+++ b/custom_components/miraie/config_flow.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from datetime import date
+import calendar
+from typing import Any, Optional
 
 from miraie_ac import MirAIeHub
 import voluptuous as vol
@@ -12,19 +14,50 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import DOMAIN
+from .const import CONF_INSTALL_DATE, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_USER_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required("username"): str,
-        vol.Required("password"): str,
-    }
-)
+def months_ago(today: date, months: int) -> date:
+    month = today.month - months
+    year = today.year
+    if month <= 0:
+        month += 12
+        year -= 1
+    day = min(today.day, calendar.monthrange(year, month)[1])
+    return date(year, month, day)
 
 
-async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+def six_months_ago(today: date) -> date:
+    return months_ago(today, 6)
+
+
+def eight_months_ago(today: date) -> date:
+    return months_ago(today, 8)
+
+
+def parse_install_date(value: str) -> Optional[date]:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise InvalidInstallDate from exc
+
+
+def build_user_schema(default_install_date: str) -> vol.Schema:
+    return vol.Schema(
+        {
+            vol.Required("username"): str,
+            vol.Required("password"): str,
+            vol.Optional(CONF_INSTALL_DATE, default=default_install_date): str,
+        }
+    )
+
+
+async def validate_input(
+    hass: HomeAssistant, data: dict[str, Any]
+) -> tuple[dict[str, Any], Optional[date]]:
     """Validate the user input allows us to connect.
 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
@@ -42,7 +75,8 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     # InvalidAuth
 
     # Return info that you want to store in the config entry.
-    return {"title": "MirAIe"}
+    install_date = parse_install_date(data.get(CONF_INSTALL_DATE, ""))
+    return {"title": "MirAIe"}, install_date
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -55,27 +89,46 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle the initial step."""
         if user_input is None:
+            default_install = six_months_ago(date.today()).isoformat()
             return self.async_show_form(
-                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
+                step_id="user", data_schema=build_user_schema(default_install)
             )
 
         errors = {}
 
         try:
-            info = await validate_input(self.hass, user_input)
+            info, install_date = await validate_input(self.hass, user_input)
+            today = date.today()
+            min_date = six_months_ago(today)
+            oldest_date = eight_months_ago(today)
+            if install_date is None:
+                install_date = min_date
+            if install_date < oldest_date or install_date > today:
+                errors[CONF_INSTALL_DATE] = "invalid_install_date"
+                raise InvalidInstallDate
         except CannotConnect:
             errors["base"] = "cannot_connect"
         except InvalidAuth:
             errors["base"] = "invalid_auth"
+        except InvalidInstallDate:
+            errors[CONF_INSTALL_DATE] = "invalid_install_date"
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
         else:
-            return self.async_create_entry(title=info["title"], data=user_input)
+            options = {CONF_INSTALL_DATE: install_date.isoformat()}
+            data = {k: v for k, v in user_input.items() if k != CONF_INSTALL_DATE}
+            return self.async_create_entry(title=info["title"], data=data, options=options)
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="user",
+            data_schema=build_user_schema(user_input.get(CONF_INSTALL_DATE, "")),
+            errors=errors,
         )
+
+    @staticmethod
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry):
+        return OptionsFlowHandler(config_entry)
 
 
 class CannotConnect(HomeAssistantError):
@@ -84,3 +137,55 @@ class CannotConnect(HomeAssistantError):
 
 class InvalidAuth(HomeAssistantError):
     """Error to indicate there is invalid auth."""
+
+
+class InvalidInstallDate(HomeAssistantError):
+    """Error to indicate invalid installation date."""
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options flow for mirAIe."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        if user_input is None:
+            today = date.today()
+            default_install = six_months_ago(today).isoformat()
+            current = self.config_entry.options.get(CONF_INSTALL_DATE, default_install)
+            return self.async_show_form(
+                step_id="init",
+                data_schema=vol.Schema(
+                    {vol.Optional(CONF_INSTALL_DATE, default=current): str}
+                ),
+            )
+
+        errors = {}
+        try:
+            install_date = parse_install_date(user_input.get(CONF_INSTALL_DATE, ""))
+            today = date.today()
+            min_date = six_months_ago(today)
+            oldest_date = eight_months_ago(today)
+            if install_date is None:
+                install_date = min_date
+            if install_date < oldest_date or install_date > today:
+                errors[CONF_INSTALL_DATE] = "invalid_install_date"
+                raise InvalidInstallDate
+        except InvalidInstallDate:
+            errors[CONF_INSTALL_DATE] = "invalid_install_date"
+        else:
+            return self.async_create_entry(
+                title="",
+                data={CONF_INSTALL_DATE: install_date.isoformat()},
+            )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {vol.Optional(CONF_INSTALL_DATE, default=user_input.get(CONF_INSTALL_DATE, "")): str}
+            ),
+            errors=errors,
+        )

--- a/custom_components/miraie/const.py
+++ b/custom_components/miraie/const.py
@@ -2,6 +2,7 @@
 
 DOMAIN = "miraie"
 PACKAGE_NAME = "custom_components.miraie"
+CONF_INSTALL_DATE = "install_date"
 
 # Possible swing state
 H0 = "H0"

--- a/custom_components/miraie/manifest.json
+++ b/custom_components/miraie/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/miraie",
   "requirements": [
-    "miraie-ac==1.1.1",
+    "miraie-ac>=1.1.2",
     "aiomqtt>=2.0.1"
   ],
   "ssdp": [],
@@ -17,5 +17,5 @@
     "@gutpull"
   ],
   "iot_class": "cloud_push",
-  "version": "1.1.6"
+  "version": "1.1.7"
 }

--- a/custom_components/miraie/sensor.py
+++ b/custom_components/miraie/sensor.py
@@ -1,10 +1,18 @@
 from abc import ABC, abstractmethod
-from datetime import datetime, timezone, timedelta
+import calendar
+from datetime import date, datetime, timezone, timedelta
 
 import aiohttp
 from miraie_ac import Device as MirAIeDevice, MirAIeHub, ConsumptionPeriodType
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
+from homeassistant.components.recorder import get_instance
+from homeassistant.components.recorder.statistics import (
+    StatisticData,
+    StatisticMetaData,
+    async_add_external_statistics,
+    get_last_statistics,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant
@@ -18,6 +26,16 @@ from .utils import get_last_sunday
 
 
 CUTOFF_HOUR = 12
+
+
+def six_months_ago(today: date) -> date:
+    month = today.month - 6
+    year = today.year
+    if month <= 0:
+        month += 12
+        year -= 1
+    day = min(today.day, calendar.monthrange(year, month)[1])
+    return date(year, month, day)
 
 class MirAIeEnergySensor(SensorEntity, ABC):
     """Sensor for AC Power Consumption."""
@@ -168,3 +186,82 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             sensor.async_write_ha_state()  # Ensure HA is notified of new data
 
     async_track_time_interval(hass, update_sensors, timedelta(minutes=30))
+
+
+async def async_backfill_energy_statistics(
+    hass: HomeAssistant,
+    hub: MirAIeHub,
+    device: MirAIeDevice,
+    default_start_date: date,
+) -> None:
+    """Backfill daily energy history into HA recorder statistics."""
+    if not hub.http or hub.http.closed:
+        hub.http = aiohttp.ClientSession()
+
+    statistic_id = f"{DOMAIN}:{device.id}_daily_energy"
+    last_stats = await get_instance(hass).async_add_executor_job(
+        get_last_statistics, hass, 2, statistic_id, False, {"sum"}
+    )
+
+    start_date = default_start_date
+    last_sum = 0.0
+    if last_stats and last_stats.get(statistic_id):
+        entries = last_stats[statistic_id]
+        last = entries[0]
+        last_start = datetime.fromtimestamp(last["start"], tz=timezone.utc)
+        start_date = last_start.date()
+        last_sum = float(entries[1].get("sum") or 0.0) if len(entries) > 1 else 0.0
+
+    end_date = datetime.today().date()
+    if start_date > end_date:
+        LOGGER.info(
+            "Backfill: no new daily data for %s (up to %s)",
+            device.friendly_name,
+            end_date.isoformat(),
+        )
+        return
+
+    daily = await hub.get_energy_consumption_full(
+        device, ConsumptionPeriodType.DAILY, start_date, end_date
+    )
+    if not daily:
+        LOGGER.info("Backfill: no data returned for %s", device.friendly_name)
+        return
+
+    statistics = []
+    running_sum = last_sum
+    first_day = last_day = None
+    for key in sorted(daily.keys(), key=lambda k: datetime.strptime(k, "%d%m%Y").date()):
+        day = datetime.strptime(key, "%d%m%Y").date()
+        if day < start_date or day > end_date:
+            continue
+        value = daily.get(key)
+        if value is None:
+            continue
+        running_sum += float(value)
+        start_dt = datetime.combine(day, datetime.min.time(), tzinfo=timezone.utc)
+        statistics.append(StatisticData(start=start_dt, sum=running_sum, state=running_sum))
+        if first_day is None:
+            first_day = day
+        last_day = day
+
+    if not statistics:
+        LOGGER.info("Backfill: no new points built for %s", device.friendly_name)
+        return
+
+    metadata = StatisticMetaData(
+        has_mean=False,
+        has_sum=True,
+        name=f"{device.friendly_name} Daily Energy",
+        source=DOMAIN,
+        statistic_id=statistic_id,
+        unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    )
+    async_add_external_statistics(hass, metadata, statistics)
+    LOGGER.info(
+        "Backfill: added %s daily points for %s (%s to %s)",
+        len(statistics),
+        device.friendly_name,
+        first_day.isoformat(),
+        last_day.isoformat(),
+    )

--- a/custom_components/miraie/strings.json
+++ b/custom_components/miraie/strings.json
@@ -2,20 +2,32 @@
   "config": {
     "step": {
       "user": {
+        "description": "We backfill energy statistics from this date. MirAIe keeps up to ~8 months of data, so earlier dates are not supported. Leave blank to default to the last 6 months.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "install_date": "History start date (YYYY-MM-DD)"
         }
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "invalid_install_date": "Date cannot be in the future or more than 8 months back (MirAIe keeps ~8 months)"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "install_date": "History start date (YYYY-MM-DD)"
+        }
+      }
     }
   }
 }

--- a/custom_components/miraie/translations/en.json
+++ b/custom_components/miraie/translations/en.json
@@ -6,14 +6,26 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error"
+            "unknown": "Unexpected error",
+            "invalid_install_date": "Date cannot be in the future or more than 8 months back (MirAIe keeps ~8 months)"
         },
         "step": {
             "user": {
+                "description": "We backfill energy statistics from this date. MirAIe keeps up to ~8 months of data, so earlier dates are not supported. Leave blank to default to the last 6 months.",
                 "data": {
                     "host": "Host",
                     "password": "Password",
-                    "username": "Username"
+                    "username": "Username",
+                    "install_date": "History start date (YYYY-MM-DD)"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "install_date": "History start date (YYYY-MM-DD)"
                 }
             }
         }


### PR DESCRIPTION
> **⚠️ Draft — depends on a pending upstream change**
> This PR requires `miraie-ac>=1.1.2` which adds `get_energy_consumption_full`. That method is not yet published to PyPI — track progress at: [rkzofficial/miraie-ac#19](https://github.com/rkzofficial/miraie-ac/pull/19). The `manifest.json` version placeholder will be pinned to the exact release before merging.

## Summary

Backfills daily energy consumption into HA recorder statistics, enabling historical data in the Energy dashboard.

- On startup and nightly at 00:05, `async_backfill_energy_statistics` fetches daily energy history from the MirAIe API and inserts it as external statistics into HA's recorder
- Incremental: picks up from the last stored data point so repeated runs don't re-fetch everything
- Adds an optional **History start date** field to the config flow (and options flow) so users can control how far back to backfill — defaults to 6 months ago, capped at 8 months (MirAIe API limit)

## Dependency

Uses `get_energy_consumption_full` from `miraie-ac>=1.1.2` to fetch arbitrary date ranges by chunking requests within the API's 6-month limit.