### PR TITLE
chore: require miraie-ac 1.1.2

### DIFF
--- a/custom_components/miraie/manifest.json
+++ b/custom_components/miraie/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/miraie",
   "requirements": [
-    "miraie-ac==1.1.1",
+    "miraie-ac==1.1.2",
     "aiomqtt>=2.0.1"
   ],
   "ssdp": [],


### PR DESCRIPTION
## Summary

Bump the required `miraie-ac` version from `1.1.1` to `1.1.2` in the integration manifest.

## Why

`miraie-ac` 1.1.2 includes the fix for incorrectly encoded `rmtmp` room temperature values from newer Panasonic firmware (see https://github.com/rkzofficial/miraie-ac/pull/22). This bump ensures the integration pulls in the corrected library that decodes values like `150.27` -> `27`, `2.29` -> `29`.

## Changes

- **`custom_components/miraie/manifest.json`**: `miraie-ac==1.1.1` -> `miraie-ac==1.1.2`.