### PR TITLE
chore: bump integration version to 1.1.8

### DIFF
--- a/custom_components/miraie/manifest.json
+++ b/custom_components/miraie/manifest.json
@@ -17,5 +17,5 @@
     "@gutpull"
   ],
   "iot_class": "cloud_push",
-  "version": "1.1.7"
+  "version": "1.1.8"
 }


### PR DESCRIPTION
## Summary

Bump the integration version from `1.1.7` to `1.1.8` in the manifest.

## Why

This release pulls in `miraie-ac==1.1.2` (already merged in #60), which includes the fix for incorrectly encoded `rmtmp` room temperature values from newer Panasonic firmware (see https://github.com/rkzofficial/miraie-ac/pull/22 and https://github.com/rkzofficial/miraie-ac/releases/tag/v1.1.2).

## Changes

- **`custom_components/miraie/manifest.json`**: `"version": "1.1.7"` -> `"1.1.8"`.